### PR TITLE
M2 4202 allow empty text in email body

### DIFF
--- a/src/core/helpers/markdownVariableReplacer/replaceVariablesInMarkdown.ts
+++ b/src/core/helpers/markdownVariableReplacer/replaceVariablesInMarkdown.ts
@@ -9,9 +9,9 @@ type Params = {
   items: ItemEntity[]
 }
 
-export function replaceVariablesInMarkdown({ user, markdown, items, scores }: Params): string | null {
+export function replaceVariablesInMarkdown({ user, markdown, items, scores }: Params): string {
   if (!markdown) {
-    return null
+    return ""
   }
 
   const nickname = !!user.nickname ? user.nickname : `${user.firstName} ${user.lastName}`.trim()


### PR DESCRIPTION
Allow empty body in email (text)

- Empty email body text can be received from BE 
- Approved from BA side