### PR TITLE
M2-4382: Calculate score only by unhidden activity items

### DIFF
--- a/src/models/activity.ts
+++ b/src/models/activity.ts
@@ -46,15 +46,20 @@ export class ActivityEntity {
     this.reports = data.scoresAndReports?.reports || []
   }
 
+  getVisibleItems() : ItemEntity[] {
+    return this.items.filter((item) => !item.json.isHidden)
+  }
+
   evaluateScores(responses: ResponseItem[]): KVObject {
     const answers = responses.filter((x) => x !== null)
 
     const scores: KVObject = {}
     const maxScores: KVObject = {}
 
+    const visibleItems = this.getVisibleItems()
     for (let i = 0; i < answers.length; i++) {
       const response = answers[i]
-      const item = this.items[i]
+      const item = visibleItems[i]
 
       scores[item.name] = item.getScore(response)
       maxScores[item.name] = item.getMaxScore()


### PR DESCRIPTION
Hidden items has been not skipped in score calculation and collapse all total average and sum value

https://mindlogger.atlassian.net/browse/M2-4382