### PR TITLE
M2-4294:if response is null, skip without any calc

### DIFF
--- a/src/models/activity.ts
+++ b/src/models/activity.ts
@@ -51,19 +51,16 @@ export class ActivityEntity {
   }
 
   evaluateScores(responses: ResponseItem[]): KVObject {
-    // const answers = responses.filter((x) => x !== null)
     const answers = responses
 
     const scores: KVObject = {}
     const maxScores: KVObject = {}
 
-    // const visibleItems = this.getVisibleItems()
     for (let i = 0; i < answers.length; i++) {
       const response = answers[i]
       if (response === null) {
         continue;
       }
-      // const item = visibleItems[i]
       const item = this.items[i]
       
       scores[item.name] = item.getScore(response)

--- a/src/models/activity.ts
+++ b/src/models/activity.ts
@@ -51,16 +51,21 @@ export class ActivityEntity {
   }
 
   evaluateScores(responses: ResponseItem[]): KVObject {
-    const answers = responses.filter((x) => x !== null)
+    // const answers = responses.filter((x) => x !== null)
+    const answers = responses
 
     const scores: KVObject = {}
     const maxScores: KVObject = {}
 
-    const visibleItems = this.getVisibleItems()
+    // const visibleItems = this.getVisibleItems()
     for (let i = 0; i < answers.length; i++) {
       const response = answers[i]
-      const item = visibleItems[i]
-
+      if (response === null) {
+        continue;
+      }
+      // const item = visibleItems[i]
+      const item = this.items[i]
+      
       scores[item.name] = item.getScore(response)
       maxScores[item.name] = item.getMaxScore()
     }


### PR DESCRIPTION
resolves: [M2-4294](https://mindlogger.atlassian.net/browse/M2-4294
), [M2-4199](https://mindlogger.atlassian.net/browse/M2-4199)

### Objective
Fix report server error if activity has skippable or hidden items
### Notes
When activity item is skipped, hidden, or not shown due to conditional logic, answer should be `null`, with item id inside `item_ids`

[M2-4294]: https://mindlogger.atlassian.net/browse/M2-4294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[M2-4199]: https://mindlogger.atlassian.net/browse/M2-4199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ