### PR TITLE
fix: add subscale settings null validation (M2-8076)

### DIFF
--- a/src/core/interfaces/index.ts
+++ b/src/core/interfaces/index.ts
@@ -39,7 +39,7 @@ export interface IActivity {
   reportIncludedItemName: string
   responseIsEditable: boolean
   scoresAndReports: IActivityScoresAndReports
-  subscaleSetting: ActivitySubscalesSetting
+  subscaleSetting?: ActivitySubscalesSetting
   showAllAtOnce: boolean
   splashScreen: string
   items: IActivityItem[]

--- a/src/models/activity.ts
+++ b/src/models/activity.ts
@@ -42,7 +42,7 @@ export class ActivityEntity {
   public reportIncludeItem: string
   public allowSummary: boolean
   public reports: IActivityScoresAndReportsSections[] | IActivityScoresAndReportsScores[]
-  public subscaleSetting: ActivitySubscalesSetting
+  public subscaleSetting?: ActivitySubscalesSetting
 
   constructor(data: IActivity, items: IActivityItem[] = []) {
     this.json = data
@@ -61,7 +61,7 @@ export class ActivityEntity {
 
     this.allowSummary = data.scoresAndReports?.showScoreSummary || false
     this.reports = data.scoresAndReports?.reports || []
-    this.subscaleSetting = data.subscaleSetting || null
+    this.subscaleSetting = data.subscaleSetting
   }
 
   getVisibleItems(): ItemEntity[] {
@@ -111,7 +111,7 @@ export class ActivityEntity {
             break
         }
 
-        const subscaleItem = this.subscaleSetting.subscales.find(({ name }) => name === report.subscaleName)
+        const subscaleItem = this.subscaleSetting?.subscales.find(({ name }) => name === report.subscaleName)
 
         if (subscaleItem?.subscaleTableData && subscaleItem.subscaleTableData.length > 0) {
           const calculatedScore = scores[report.id]


### PR DESCRIPTION
### Description

Attempting to generate a report with an applet with a null `subscaleSetting` results in an error

[M2-8076](https://mindlogger.atlassian.net/browse/M2-8076)

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/5daee7b4-3e09-4560-9552-f7c1fce43b56)|![CleanShot 2024-10-21 at 08 50 02](https://github.com/user-attachments/assets/0a9cee32-4412-4682-a662-c8701fdb0233)|


[M2-8076]: https://mindlogger.atlassian.net/browse/M2-8076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ