### PR TITLE
fix: Account for the way the mobile app represents number selections (M2-8174)

### DIFF
--- a/src/models/activity.ts
+++ b/src/models/activity.ts
@@ -130,7 +130,6 @@ export class ActivityEntity {
               reportedAge = String(ageAnswer)
             }
 
-            // const withAge = age === reportedAge
             const hasAgeInterval = age && typeof age === 'string' && age.includes(INTERVAL_SYMBOL)
             let withAge = true
 

--- a/src/models/activity.ts
+++ b/src/models/activity.ts
@@ -125,7 +125,7 @@ export class ActivityEntity {
             let reportedAge: number | null = null
             if (typeof ageAnswer === 'string') {
               reportedAge = Number(ageAnswer)
-            } else if ('value' in ageAnswer && typeof ageAnswer.value === 'number') {
+            } else if ('value' in ageAnswer && ['number', 'string'].includes(typeof ageAnswer.value)) {
               reportedAge = ageAnswer.value
             }
 

--- a/src/models/activity.ts
+++ b/src/models/activity.ts
@@ -123,11 +123,10 @@ export class ActivityEntity {
 
           const subscaleTableDataItem = subscaleTableData.find(({ sex, age, rawScore }) => {
             let reportedAge: string | null = null
-            if (
-              typeof ageAnswer === 'string' ||
-              ('value' in ageAnswer && ['number', 'string'].includes(typeof ageAnswer.value))
-            ) {
-              reportedAge = String(ageAnswer)
+            if (typeof ageAnswer === 'string') {
+              reportedAge = ageAnswer
+            } else if (ageAnswer && 'value' in ageAnswer && ['number', 'string'].includes(typeof ageAnswer.value)) {
+              reportedAge = String(ageAnswer.value)
             }
 
             const hasAgeInterval = age && typeof age === 'string' && age.includes(INTERVAL_SYMBOL)

--- a/src/models/activity.ts
+++ b/src/models/activity.ts
@@ -122,14 +122,28 @@ export class ActivityEntity {
           const subscaleTableData = subscaleItem.subscaleTableData
 
           const subscaleTableDataItem = subscaleTableData.find(({ sex, age, rawScore }) => {
-            let reportedAge: number | null = null
-            if (typeof ageAnswer === 'string') {
-              reportedAge = Number(ageAnswer)
-            } else if ('value' in ageAnswer && ['number', 'string'].includes(typeof ageAnswer.value)) {
-              reportedAge = ageAnswer.value
+            let reportedAge: string | null = null
+            if (
+              typeof ageAnswer === 'string' ||
+              ('value' in ageAnswer && ['number', 'string'].includes(typeof ageAnswer.value))
+            ) {
+              reportedAge = String(ageAnswer)
             }
 
-            const withAge = age === reportedAge
+            // const withAge = age === reportedAge
+            const hasAgeInterval = age && typeof age === 'string' && age.includes(INTERVAL_SYMBOL)
+            let withAge = true
+
+            if (age) {
+              if (!hasAgeInterval) {
+                withAge = String(age) === reportedAge
+              } else {
+                const [minAge, maxAge] = age.replace(/\s/g, '').split(INTERVAL_SYMBOL)
+                const reportedAgeNum = Number(reportedAge)
+                withAge = Number(minAge) <= reportedAgeNum && reportedAgeNum <= Number(maxAge)
+              }
+            }
+
             const withSex = parseSex(sex) === String(genderAnswer?.value)
 
             if (!withSex || !withAge) return false


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-8174](https://mindlogger.atlassian.net/browse/M2-8174)

This PR updates the T score calculation to account for the way the mobile app represents number selections. 

The mobile app will submit the answer to the age question as a number selection when the admin configures the field as a dropdown. However, its representation of this data differs from the web app: the mobile app will use a string, whereas the web app uses a number. Therefore, we need to account for both in the report generation.

### 📸 Screenshots

N/A

### 🪤 Peer Testing

1. Create an activity with at least one scorable item
2. Create a subscale with a lookup table containing severity information
    <details>
      <summary>Here's a sample one</summary>
      
      ```csv
      score,rawScore,age,sex,optionalText,severity
     10,1,15,M,https://gist.githubusercontent.com/benbalter/3914310/raw/f757a33411082da23f0ad4a124b45fcdacc1b43f/Example--text.txt,Minimal
      20,2,15,M,https://gist.githubusercontent.com/benbalter/3914310/raw/f757a33411082da23f0ad4a124b45fcdacc1b43f/Example--text.txt,Mild
      30,3,15,M,Markdown Text Here,Moderate
      40,4,15,F,Good,Severe
      50,5,15,F,Nice,Severe
      ```
    </details>
3. Switch the age field type to dropdown in the subscale settings
4. Create a report score that uses scoring type "Score" and link it to the subscale from earlier
5. Add a score condition to the report score that relies on the score being equal to one from the `score` column of the lookup table (e.g. score is equal to 30)
6. Save and complete the activity via the mobile app. Complete the activity such that the total score will match the entry in the `rawScore` column of the lookup table in the same row as the score from the score condition (e.g. the total score will be 3, and you will select Male and 15 for the sex and age respectively, which will map to the 30 from above)
7. Download the latest PDF report for the participant in the activity
8. Verify that the message from the score condition is present

### ✏️ Notes

I haven't been able to verify this locally. My reports keep coming up empty for what I think is an unrelated reason. Nevertheless, I wanted to get this into more hands so that it can be reviewed
