### PR TITLE
Include numberSelect type for possible types of itemEntity itemType a…

### DIFF
--- a/src/models/item.ts
+++ b/src/models/item.ts
@@ -173,7 +173,7 @@ export class ItemEntity {
   }
 
   getPrinted(value: ResponseItem, context: { items: ItemEntity[]; responses: ResponseItem[] | string[] }): string {
-    const allowedTypes = ['singleSelect', 'multiSelect', 'slider', 'text']
+    const allowedTypes = ['singleSelect', 'multiSelect', 'slider', 'text', 'numberSelect']
 
     if (!allowedTypes.includes(this.inputType)) {
       return ''

--- a/src/models/item.ts
+++ b/src/models/item.ts
@@ -214,7 +214,7 @@ export class ItemEntity {
       const maxLabelHtml = `<div class="slider-value">${maxLabel}</div>`
 
       optionsHtml += `<div class="option">${minLabelHtml}<input type="range" min="${minValue}" max="${maxValue}" value="${response[0]}">${maxLabelHtml}</div>`
-    } else if (this.inputType === 'text') {
+    } else if (this.inputType === 'text' || this.inputType === 'numberSelect') {
       optionsHtml += response[0]
     }
     //additional input


### PR DESCRIPTION
📝 Description
🔗 [Jira Ticket M2-8166](https://mindlogger.atlassian.net/jira/software/c/projects/M2/boards/4?assignee=712020%3A6322a990-2eaf-42f4-9fed-30af94baf20e&selectedIssue=M2-8166)

Fixes the downloaded report and inserts the Age section when the report server was configured with Lookup table for the scores and reports section for an activity. 

GET /activities/applet/{applet_id}/respondent/{subject_id}
GET /subjects/respondent/{subject_id}/activity-or-flow/{activity_or_flow_id}
🪤 Peer Testing
You need to create an activity with lookup table and inside the Subscale setting select the dropdown option for the age parameter. The age paramater with dropdown option wasn't printed on the final report server report. This happend because the item passed inside the request (associated to the dropdown-age) wasn't defined or admited by the Report Server. 

Steps: 
- Subscale/Lookup Table Setup
- Create activity with scoring items
- Create subscale  and include any/all the items
- Upload lookup table
- Change ‘Age’ to dropdown
- PDF Report Setup
- Report configurations: Configure report server (url and public key) and specify recipient email → Save
- Create a report score and set the score type to "Score”
- Select the subscale from the dropdown list
- Toggle ON the Print items
- Save applet
- Turn on report generation on Scores&Reports
- Execute and complete activity on web and on the mobile app
- Download report from recipient’s email
- Open the report
- Search for age item response 

Notes: Still to check on mobile