### PR TITLE
fix: Add flag to puppeteer for disable crashpad

### DIFF
--- a/src/pdf-utils.ts
+++ b/src/pdf-utils.ts
@@ -10,7 +10,7 @@ import { decryptData } from './modules/report/services/kmsEncryption'
 
 export const convertHtmlToPdf = async (html: string, saveTo: string): Promise<void> => {
   const browser = await puppeteer.launch({
-    args: ['--disable-dev-shm-usage', '--no-sandbox', '--headless', '--disable-gpu'],
+    args: ['--disable-dev-shm-usage', '--no-sandbox', '--headless', '--disable-gpu', '--disable-crashpad-for-testing'],
   })
 
   const page = await browser.newPage()


### PR DESCRIPTION
Included '--disable-crashpad-for-testing' in puppeteer launch args to  preventing crash reports.

<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [ ] Tests for the changes have been added
- [ ] Related documentation has been added / updated

### 📝 Description

The error was because a fail to launch chromium browser due a folder permission error, new chromium version need write permission in a crashpad folder, so disable crashpad prevent chromium to check for permission and fail

