### PR TITLE
feat: Add support for treating skipped answers as `null` (M2-8650, M2-6099, M2-8169)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,11 +4,8 @@ module.exports = {
     project: 'tsconfig.json',
     sourceType: 'module',
   },
-  plugins: ['@typescript-eslint/eslint-plugin'],
-  extends: [
-    'plugin:@typescript-eslint/recommended',
-    'plugin:prettier/recommended',
-  ],
+  plugins: ['@typescript-eslint/eslint-plugin', 'unused-imports'],
+  extends: ['plugin:@typescript-eslint/recommended', 'plugin:prettier/recommended'],
   root: true,
   env: {
     node: true,
@@ -20,6 +17,7 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
-    'no-console': ["error", { allow: ["warn", "error", "info"] }]
+    'unused-imports/no-unused-imports': 'error',
+    'no-console': ['error', { allow: ['warn', 'error', 'info'] }],
   },
-};
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-import": "~2.31.0",
         "eslint-plugin-prettier": "^5.2.1",
+        "eslint-plugin-unused-imports": "^4.1.4",
         "jest": "^29.5.0",
         "nodemon": "^3.1.7",
         "prettier": "^3.3.3",
@@ -4984,6 +4985,22 @@
           "optional": true
         },
         "eslint-config-prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-unused-imports": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-4.1.4.tgz",
+      "integrity": "sha512-YptD6IzQjDardkl0POxnnRBhU1OEePMV0nd6siHaRBbd+lyh6NAhFEobiznKU7kTsSsDeSD62Pe7kAM1b7dAZQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0",
+        "eslint": "^9.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-import": "~2.31.0",
     "eslint-plugin-prettier": "^5.2.1",
+    "eslint-plugin-unused-imports": "^4.1.4",
     "jest": "^29.5.0",
     "nodemon": "^3.1.7",
     "prettier": "^3.3.3",

--- a/src/core/helpers/ScoresCalculator.ts
+++ b/src/core/helpers/ScoresCalculator.ts
@@ -60,7 +60,7 @@ export class ScoresCalculator {
       scores = [checkboxAnswers]
     }
 
-    const numericScores = scores.filter((x) => x !== null)
+    const numericScores = scores.filter((x): x is number => x !== null)
     if (numericScores.length === 0) {
       return null
     }

--- a/src/core/helpers/ScoresCalculator.ts
+++ b/src/core/helpers/ScoresCalculator.ts
@@ -29,40 +29,46 @@ export class ScoresCalculator {
 
     switch (item.inputType) {
       case 'slider':
-        return this.collectScoreForSlider(item, answer.value as number)
+        return this.collectScoreForSlider(item, answer.value as null | number)
       case 'singleSelect':
-        return this.collectScoreForSingleSelect(item, answer.value as number)
+        return this.collectScoreForSingleSelect(item, answer.value as null | number)
       case 'multiSelect':
-        return this.collectScoreForMultiSelect(item, answer.value as number[])
+        return this.collectScoreForMultiSelect(item, answer.value as null | Array<null | number>)
       default:
         return null
     }
   }
 
-  public static collectScoreForMultiSelect(item: ItemEntity, checkboxAnswers: number[] | number): number | null {
+  public static collectScoreForMultiSelect(
+    item: ItemEntity,
+    checkboxAnswers: null | number | Array<null | number>,
+  ): number | null {
     if (checkboxAnswers == null) {
       return null
     }
 
-    let scores: number[]
+    let scores: Array<number | null> = []
     if (Array.isArray(checkboxAnswers)) {
-      scores = item.options
-        .map<number | null>((option) => {
-          const foundAnswer = checkboxAnswers?.find((checkboxAnswer) => {
-            return checkboxAnswer === option.value
-          })
-
-          return foundAnswer !== undefined ? option.score : null
+      scores = item.options.map<number | null>((option) => {
+        const foundAnswer = checkboxAnswers?.find((checkboxAnswer) => {
+          return checkboxAnswer === option.value
         })
-        .filter((x) => x !== null) as number[]
+
+        return foundAnswer !== undefined ? option.score : null
+      })
     } else {
       scores = [checkboxAnswers]
     }
 
-    return Calculator.sum(scores)
+    const numericScores = scores.filter((x) => x !== null)
+    if (numericScores.length === 0) {
+      return null
+    }
+
+    return Calculator.sum(numericScores)
   }
 
-  public static collectScoreForSingleSelect(item: ItemEntity, radioAnswer: number): number | null {
+  public static collectScoreForSingleSelect(item: ItemEntity, radioAnswer: number | null): number | null {
     if (radioAnswer === null) {
       return null
     }
@@ -72,11 +78,12 @@ export class ScoresCalculator {
     return option ? option.score : null
   }
 
-  public static collectScoreForSlider(item: ItemEntity, itemAnswer: number): number | null {
-    const sliderAnswer = itemAnswer
+  public static collectScoreForSlider(item: ItemEntity, sliderAnswer: number | null): number | null {
+    if (sliderAnswer === null) {
+      return null
+    }
 
-    const minValue = item.json.responseValues.minValue
-    const maxValue = item.json.responseValues.maxValue
+    const { minValue, maxValue } = item.json.responseValues
 
     if (sliderAnswer < minValue || sliderAnswer > maxValue) {
       return null
@@ -88,7 +95,7 @@ export class ScoresCalculator {
       return null
     }
 
-    const valueIndex = sliderAnswer - item.json.responseValues.minValue
+    const valueIndex = sliderAnswer - minValue
     const scores = item.json.responseValues.scores ?? []
 
     return scores[valueIndex] ?? null

--- a/src/core/helpers/getScoresSummary.test.ts
+++ b/src/core/helpers/getScoresSummary.test.ts
@@ -40,7 +40,7 @@ describe('getScoresSummary', () => {
       score2: null,
       score3: 20,
     }
-    const allowedScoreNames = ['score1', 'score3']
+    const allowedScoreNames = ['score1', 'score2', 'score3']
     spyCalculatorSum.mockReturnValue(30)
 
     const result = getScoresSummary(scores, allowedScoreNames)

--- a/src/core/helpers/getScoresSummary.test.ts
+++ b/src/core/helpers/getScoresSummary.test.ts
@@ -1,0 +1,75 @@
+import { getScoresSummary } from './getScoresSummary'
+import { Calculator } from './calculator'
+
+describe('getScoresSummary', () => {
+  const spyCalculatorSum = jest.spyOn(Calculator, 'sum')
+
+  beforeEach(() => {
+    spyCalculatorSum.mockClear()
+  })
+
+  it('should return null when no allowed scores are present', () => {
+    const scores = {
+      score1: null,
+      score2: null,
+    }
+    const allowedScoreNames = ['score1', 'score2']
+
+    const result = getScoresSummary(scores, allowedScoreNames)
+
+    expect(result).toBeNull()
+    expect(spyCalculatorSum).not.toHaveBeenCalled()
+  })
+
+  it('should return null when no score names are allowed', () => {
+    const scores = {
+      score1: 10,
+      score2: 20,
+    }
+    const allowedScoreNames: string[] = []
+
+    const result = getScoresSummary(scores, allowedScoreNames)
+
+    expect(result).toBeNull()
+    expect(spyCalculatorSum).not.toHaveBeenCalled()
+  })
+
+  it('should return the sum of allowed non-null scores', () => {
+    const scores = {
+      score1: 10,
+      score2: null,
+      score3: 20,
+    }
+    const allowedScoreNames = ['score1', 'score3']
+    spyCalculatorSum.mockReturnValue(30)
+
+    const result = getScoresSummary(scores, allowedScoreNames)
+
+    expect(result).toBe(30)
+    expect(spyCalculatorSum).toHaveBeenCalledWith([10, 20])
+  })
+
+  it('should filter out scores not in allowed score names', () => {
+    const scores = {
+      score1: 10,
+      score2: 20,
+      score3: 30,
+    }
+    const allowedScoreNames = ['score1', 'score3']
+
+    const result = getScoresSummary(scores, allowedScoreNames)
+
+    expect(result).toBe(30)
+    expect(spyCalculatorSum).toHaveBeenCalledWith([10, 30])
+  })
+
+  it('should handle an empty scores object', () => {
+    const scores = {}
+    const allowedScoreNames = ['score1']
+
+    const result = getScoresSummary(scores, allowedScoreNames)
+
+    expect(result).toBeNull()
+    expect(spyCalculatorSum).not.toHaveBeenCalled()
+  })
+})

--- a/src/core/helpers/getScoresSummary.ts
+++ b/src/core/helpers/getScoresSummary.ts
@@ -1,12 +1,12 @@
 import { Map } from '../interfaces'
 import { Calculator } from './calculator'
 
-export function getScoresSummary(scores: Map, allowedScoreNames: string[]): number {
+export function getScoresSummary(scores: Map<number | null>, allowedScoreNames: string[]): number | null {
   const allowedScores: number[] = []
   for (const name in scores) {
-    if (allowedScoreNames.includes(name)) {
+    if (allowedScoreNames.includes(name) && scores[name] !== null) {
       allowedScores.push(scores[name])
     }
   }
-  return Calculator.sum(allowedScores)
+  return allowedScores.length ? Calculator.sum(allowedScores) : null
 }

--- a/src/core/helpers/getScoresSummary.ts
+++ b/src/core/helpers/getScoresSummary.ts
@@ -4,8 +4,9 @@ import { Calculator } from './calculator'
 export function getScoresSummary(scores: Map<number | null>, allowedScoreNames: string[]): number | null {
   const allowedScores: number[] = []
   for (const name in scores) {
-    if (allowedScoreNames.includes(name) && scores[name] !== null) {
-      allowedScores.push(scores[name])
+    const score = scores[name]
+    if (allowedScoreNames.includes(name) && score !== null) {
+      allowedScores.push(score)
     }
   }
   return allowedScores.length ? Calculator.sum(allowedScores) : null

--- a/src/core/helpers/isArray/index.ts
+++ b/src/core/helpers/isArray/index.ts
@@ -1,3 +1,3 @@
-export function isArray<T>(value: T): boolean {
+export function isArray(value: any): value is Array<any> {
   return Array.isArray(value)
 }

--- a/src/core/helpers/isFloat/index.ts
+++ b/src/core/helpers/isFloat/index.ts
@@ -1,6 +1,6 @@
 import { isString } from '../isString'
 
-export function isFloat(inputString: any): boolean {
+export function isFloat(inputString: any): inputString is number | string {
   if (Array.isArray(inputString)) {
     return false
   }

--- a/src/core/helpers/isNumber/index.ts
+++ b/src/core/helpers/isNumber/index.ts
@@ -1,3 +1,3 @@
-export function isNumber<T>(value: T): boolean {
+export function isNumber(value: any): value is number {
   return typeof value === 'number'
 }

--- a/src/core/helpers/isObject/index.ts
+++ b/src/core/helpers/isObject/index.ts
@@ -1,3 +1,3 @@
-export function isObject<T>(value: T): boolean {
+export function isObject(value: any): value is object {
   return typeof value === 'object'
 }

--- a/src/core/helpers/isString/index.ts
+++ b/src/core/helpers/isString/index.ts
@@ -1,3 +1,3 @@
-export function isString<T>(value: T): boolean {
+export function isString(value: any): value is string {
   return typeof value === 'string'
 }

--- a/src/core/interfaces/index.ts
+++ b/src/core/interfaces/index.ts
@@ -205,7 +205,7 @@ export type ActivityResponse = {
 export type SingleResponseValue = string | number | null
 export type ResponseValue = SingleResponseValue | SingleResponseValue[] | Array<SingleResponseValue[] | null>
 
-export type ResponseItem = {
+export type ResponseItem = null | {
   value: ResponseValue
   text?: string
 }
@@ -218,7 +218,7 @@ export type Map<T = any> = {
 
 export interface ScoreForSummary {
   prefLabel: string
-  value: number
+  value: Score
   flagScore: boolean
 }
 

--- a/src/core/interfaces/index.ts
+++ b/src/core/interfaces/index.ts
@@ -202,13 +202,18 @@ export type ActivityResponse = {
   data: ResponseItem[]
 }
 
+export type SingleResponseValue = string | number | null
+export type ResponseValue = SingleResponseValue | SingleResponseValue[] | Array<SingleResponseValue[] | null>
+
 export type ResponseItem = {
-  value: any
+  value: ResponseValue
   text?: string
 }
 
-export type Map = {
-  [key: string]: any
+export type Score = string | number | null
+
+export type Map<T = any> = {
+  [key: string]: T
 }
 
 export interface ScoreForSummary {

--- a/src/models/activity.ts
+++ b/src/models/activity.ts
@@ -114,7 +114,7 @@ export class ActivityEntity {
 
           case 'average':
             const actualScores = ScoresCalculator.collectActualScores(this.items, report.itemsScore, responses)
-            const filteredScores: number[] = actualScores.filter((x) => x !== null)
+            const filteredScores: number[] = actualScores.filter((x): x is number => x !== null)
 
             if (filteredScores.length === 0) {
               scores[report.id] = null

--- a/src/models/activity.ts
+++ b/src/models/activity.ts
@@ -46,7 +46,9 @@ export class ActivityEntity {
   public reports: IActivityScoresAndReportsSections[] | IActivityScoresAndReportsScores[]
   public subscaleSetting?: ActivitySubscalesSetting
 
-  constructor(data: IActivity, items: IActivityItem[] = []) {
+  // TODO: Remove `treatNullAsZero` when 'enable-subscale-null-when-skipped' feature flag is removed
+  // https://mindlogger.atlassian.net/browse/M2-8635
+  constructor(data: IActivity, items: IActivityItem[] = [], treatNullAsZero: boolean) {
     this.json = data
 
     this.schemaId = data.id
@@ -55,7 +57,7 @@ export class ActivityEntity {
     this.splashImage = data.splashScreen
 
     this.items = items.map((item) => {
-      return new ItemEntity(item)
+      return new ItemEntity(item, treatNullAsZero)
     })
 
     //TODO: activity.items.find(item => item.name == activity.reportIncludeItem);
@@ -70,15 +72,13 @@ export class ActivityEntity {
     return this.items.filter((item) => !item.json.isHidden)
   }
 
-  evaluateScores(responses: ResponseItem[]): Map {
-    const answers = responses
-
+  evaluateScores(responses: ResponseItem[]) {
     const scores: Map<Score> = {}
-    const maxScores: Map<Score> = {}
+    const maxScores: Map<number | null> = {}
     const conditionalVisibility: Map<boolean> = {}
 
-    for (let i = 0; i < answers.length; i++) {
-      const response = answers[i]
+    for (let i = 0; i < responses.length; i++) {
+      const response = responses[i]
       const item = this.items[i]
 
       scores[item.name] = item.getScore(response)
@@ -88,8 +88,8 @@ export class ActivityEntity {
     // calculate scores first
     for (const report of this.reports) {
       if (report.type === 'score') {
-        const reportScore = getScoresSummary(scores, report.itemsScore)
-        const reportMaxScore = getScoresSummary(maxScores, report.itemsScore)
+        const reportScore = getScoresSummary(scores as Map<number | null>, report.itemsScore)
+        const reportMaxScore = getScoresSummary(maxScores as Map<number>, report.itemsScore) as number
 
         maxScores[report.id] = reportMaxScore
 
@@ -97,7 +97,12 @@ export class ActivityEntity {
           case 'sum':
             scores[report.id] = reportScore
             break
+
           case 'percentage':
+            if (reportScore === null) {
+              scores[report.id] = null
+              break
+            }
             if (reportMaxScore === 0) {
               scores[report.id] = 0
               break
@@ -106,10 +111,15 @@ export class ActivityEntity {
 
             scores[report.id] = toFixed(percentageScore)
             break
-          case 'average':
-            const score = ScoresCalculator.collectActualScores(this.items, report.itemsScore, responses)
-            const filteredScores: number[] = score.filter((x) => x !== null).map((x) => x!)
 
+          case 'average':
+            const actualScores = ScoresCalculator.collectActualScores(this.items, report.itemsScore, responses)
+            const filteredScores: number[] = actualScores.filter((x) => x !== null)
+
+            if (filteredScores.length === 0) {
+              scores[report.id] = null
+              break
+            }
             scores[report.id] = toFixed(Calculator.avg(filteredScores))
             break
         }
@@ -118,6 +128,11 @@ export class ActivityEntity {
 
         if (subscaleItem?.subscaleTableData && subscaleItem.subscaleTableData.length > 0) {
           const calculatedScore = scores[report.id]
+          if (calculatedScore === null) {
+            scores[report.id] = null
+            break
+          }
+
           const genderItemIndex = this.items.findIndex((item) => item.name == LookupTableItems.Gender_screen)
           const genderAnswer = responses[genderItemIndex]
           const ageItemIndex = this.items.findIndex((item) => item.name == LookupTableItems.Age_screen)
@@ -145,7 +160,7 @@ export class ActivityEntity {
               }
             }
 
-            const withSex = parseSex(sex) === String(genderAnswer?.value)
+            const withSex = !sex || parseSex(sex) === String(genderAnswer?.value)
 
             if (!withSex || !withAge) return false
 
@@ -177,14 +192,14 @@ export class ActivityEntity {
     }
   }
 
-  scoresToValues(scores: Map<Score>, responses: ResponseItem[]): Map[] {
+  scoresToValues(scores: Map<Score>, responses: ResponseItem[]): [Map<Score>, Map<ResponseValue | ResponseValue[]>] {
     const values = { ...scores }
     const rawValues: Map<ResponseValue | Array<ResponseValue>> = { ...scores }
     for (let i = 0; i < responses.length; i++) {
       const response = responses[i]
       const item = this.items[i]
       values[item.name] = item.getVariableValue(response)
-      rawValues[item.name] = response?.value
+      rawValues[item.name] = response?.value ?? null
     }
     return [values, rawValues]
   }
@@ -210,8 +225,8 @@ export class ActivityEntity {
     markdown: string,
     report: IActivityScoresAndReportsSections,
     responses: ResponseItem[],
-    rawValues: Map,
-    values: Map,
+    rawValues: Map<ResponseValue | Array<ResponseValue>>,
+    values: Map<Score>,
     user: User,
   ): string {
     const isVis = this.testVisibility(report.conditionalLogic, rawValues)
@@ -250,7 +265,7 @@ export class ActivityEntity {
     markdown: string,
     report: IActivityScoresAndReportsScores,
     responses: ResponseItem[],
-    values: Map,
+    values: Map<Score>,
     user: User,
     conditionalVisibility: Map<boolean>,
   ): string {
@@ -366,7 +381,10 @@ export class ActivityEntity {
     return markdown
   }
 
-  testVisibility(conditional: IActivityScoresAndReportsConditionalLogic | null, scores: Map): boolean {
+  testVisibility(
+    conditional: IActivityScoresAndReportsConditionalLogic | null,
+    scores: Map<Score | ResponseValue | ResponseValue[]>,
+  ): boolean {
     if (!conditional) {
       return true
     }
@@ -377,7 +395,7 @@ export class ActivityEntity {
       const key = condition.itemName
 
       if (key in scores) {
-        const score = isFloat(scores[key]) ? parseFloat(scores[key]) : scores[key]
+        const score = isFloat(scores[key]) ? parseFloat(String(scores[key])) : scores[key]
 
         const checkResult = ConditionalLogicService.checkConditionByPattern({
           type: condition.type,

--- a/src/models/applet.ts
+++ b/src/models/applet.ts
@@ -20,7 +20,9 @@ export class AppletEntity {
   public activities: ActivityEntity[]
   public activityFlows: ActivityFlow[]
 
-  constructor(data: Applet) {
+  // TODO: Remove `treatNullAsZero` when 'enable-subscale-null-when-skipped' feature flag is removed
+  // https://mindlogger.atlassian.net/browse/M2-8635
+  constructor(data: Applet, treatNullAsZero: boolean) {
     this.json = data
 
     this.timestamp = Date.now()
@@ -33,7 +35,7 @@ export class AppletEntity {
 
     // parse activities
     this.activities = data.activities.map((item) => {
-      return new ActivityEntity(item, item.items)
+      return new ActivityEntity(item, item.items, treatNullAsZero)
     })
 
     // parse activity flows
@@ -68,12 +70,12 @@ export class AppletEntity {
     let emailBody = this.reportConfigs.emailBody
 
     for (const response of responses) {
-      const activity = this.activities.find((activity) => activity.id === response.activityId)
+      const activity = this.activities.find(({ id }) => id === response.activityId)
       if (!activity) {
         throw new Error(`Can't find activity ${response.activityId}`)
       }
 
-      const scores = activity.evaluateScores(response.data)
+      const { scores } = activity.evaluateScores(response.data)
 
       const [values] = activity.scoresToValues(scores, response.data)
 

--- a/src/models/item.ts
+++ b/src/models/item.ts
@@ -75,11 +75,11 @@ export class ItemEntity {
       return []
     }
     if (['singleSelectRows', 'multiSelectRows'].includes(this.inputType)) {
-      return this.getAlertsForSelectionPerRow(value.value)
+      return this.getAlertsForSelectionPerRow(value.value as Array<string | null>)
     }
 
     if (this.inputType === 'sliderRows') {
-      return this.getAlertsForSliderRow(value.value)
+      return this.getAlertsForSliderRow(value.value as Array<number | null>)
     }
 
     return this.getAlertForSimpleTypes(value, this.options)
@@ -323,7 +323,7 @@ export class ItemEntity {
   private getAlertForSimpleTypes(responseItem: ResponseItem, options: IActivityItemOption[]): string[] {
     switch (this.inputType) {
       case 'slider':
-        const value = responseItem.value
+        const value = responseItem.value as number
 
         const alerts = this.json.responseValues.alerts ?? []
         const alert = alerts.find((a) => {
@@ -362,11 +362,7 @@ export class ItemEntity {
     if (isObject(response) && !isArray(response)) {
       const { value } = response as ResponseItem
 
-      if (!isArray(value)) {
-        return [value]
-      }
-
-      return value
+      return [value].flat()
     }
 
     return [response]

--- a/src/modules/report/helpers/conditionalLogic/ConditionalLogicService.test.ts
+++ b/src/modules/report/helpers/conditionalLogic/ConditionalLogicService.test.ts
@@ -1,0 +1,346 @@
+import { ConditionalLogicService } from './ConditionalLogicService'
+
+describe('ConditionalLogicService', () => {
+  describe('checkAllRules', () => {
+    it('should return true when all results are true', () => {
+      const results = [true, true, true]
+      expect(ConditionalLogicService.checkAllRules(results)).toBe(true)
+    })
+
+    it('should return false when any result is false', () => {
+      const results = [true, false, true]
+      expect(ConditionalLogicService.checkAllRules(results)).toBe(false)
+    })
+  })
+
+  describe('checkAnyRules', () => {
+    it('should return true when any result is true', () => {
+      const results = [false, true, false]
+      expect(ConditionalLogicService.checkAnyRules(results)).toBe(true)
+    })
+
+    it('should return false when all results are false', () => {
+      const results = [false, false, false]
+      expect(ConditionalLogicService.checkAnyRules(results)).toBe(false)
+    })
+  })
+
+  describe('checkConditionByPattern', () => {
+    it('should return false for null scoreOrValue', () => {
+      const result = ConditionalLogicService.checkConditionByPattern({
+        type: 'BETWEEN',
+        payload: { minValue: 0, maxValue: 10 },
+        scoreOrValue: null,
+      })
+      expect(result).toBe(false)
+    })
+
+    describe('BETWEEN', () => {
+      it('should return true when value is between min and max', () => {
+        const result = ConditionalLogicService.checkConditionByPattern({
+          type: 'BETWEEN',
+          payload: { minValue: 0, maxValue: 10 },
+          scoreOrValue: 5,
+        })
+        expect(result).toBe(true)
+      })
+
+      it('should return false when value is not between min and max', () => {
+        const result = ConditionalLogicService.checkConditionByPattern({
+          type: 'BETWEEN',
+          payload: { minValue: 0, maxValue: 10 },
+          scoreOrValue: 15,
+        })
+        expect(result).toBe(false)
+      })
+
+      it('should return false when value is equal to min or max', () => {
+        let result = ConditionalLogicService.checkConditionByPattern({
+          type: 'BETWEEN',
+          payload: { minValue: 0, maxValue: 10 },
+          scoreOrValue: 0,
+        })
+        expect(result).toBe(false)
+
+        result = ConditionalLogicService.checkConditionByPattern({
+          type: 'BETWEEN',
+          payload: { minValue: 0, maxValue: 10 },
+          scoreOrValue: 10,
+        })
+        expect(result).toBe(false)
+      })
+    })
+
+    describe('OUTSIDE_OF', () => {
+      it('should return true when value is outside the range', () => {
+        const result = ConditionalLogicService.checkConditionByPattern({
+          type: 'OUTSIDE_OF',
+          payload: { minValue: 0, maxValue: 10 },
+          scoreOrValue: 15,
+        })
+        expect(result).toBe(true)
+      })
+
+      it('should return false when value is within the range', () => {
+        const result = ConditionalLogicService.checkConditionByPattern({
+          type: 'OUTSIDE_OF',
+          payload: { minValue: 0, maxValue: 10 },
+          scoreOrValue: 5,
+        })
+        expect(result).toBe(false)
+      })
+
+      it('should return false when value is equal to min or max', () => {
+        let result = ConditionalLogicService.checkConditionByPattern({
+          type: 'OUTSIDE_OF',
+          payload: { minValue: 0, maxValue: 10 },
+          scoreOrValue: 0,
+        })
+        expect(result).toBe(false)
+
+        result = ConditionalLogicService.checkConditionByPattern({
+          type: 'OUTSIDE_OF',
+          payload: { minValue: 0, maxValue: 10 },
+          scoreOrValue: 10,
+        })
+        expect(result).toBe(false)
+      })
+    })
+
+    describe('EQUAL_TO_OPTION', () => {
+      it('should return true when value matches option', () => {
+        const result = ConditionalLogicService.checkConditionByPattern({
+          type: 'EQUAL_TO_OPTION',
+          payload: { optionValue: '5' },
+          scoreOrValue: 5,
+        })
+        expect(result).toBe(true)
+      })
+
+      it('should return false when value does not match option', () => {
+        const result = ConditionalLogicService.checkConditionByPattern({
+          type: 'EQUAL_TO_OPTION',
+          payload: { optionValue: '5' },
+          scoreOrValue: 10,
+        })
+        expect(result).toBe(false)
+      })
+    })
+
+    describe('NOT_EQUAL_TO_OPTION', () => {
+      it('should return true when value does not match option', () => {
+        const result = ConditionalLogicService.checkConditionByPattern({
+          type: 'NOT_EQUAL_TO_OPTION',
+          payload: { optionValue: '5' },
+          scoreOrValue: 10,
+        })
+        expect(result).toBe(true)
+      })
+
+      it('should return false when value matches option', () => {
+        const result = ConditionalLogicService.checkConditionByPattern({
+          type: 'NOT_EQUAL_TO_OPTION',
+          payload: { optionValue: '5' },
+          scoreOrValue: 5,
+        })
+        expect(result).toBe(false)
+      })
+    })
+
+    describe('GREATER_THAN', () => {
+      it('should return true when value is greater than threshold', () => {
+        const result = ConditionalLogicService.checkConditionByPattern({
+          type: 'GREATER_THAN',
+          payload: { value: 5 },
+          scoreOrValue: 10,
+        })
+        expect(result).toBe(true)
+      })
+
+      it('should return false when value is not greater than threshold', () => {
+        const result = ConditionalLogicService.checkConditionByPattern({
+          type: 'GREATER_THAN',
+          payload: { value: 5 },
+          scoreOrValue: 3,
+        })
+        expect(result).toBe(false)
+      })
+
+      it('should return false when value is equal to threshold', () => {
+        const result = ConditionalLogicService.checkConditionByPattern({
+          type: 'GREATER_THAN',
+          payload: { value: 5 },
+          scoreOrValue: 5,
+        })
+        expect(result).toBe(false)
+      })
+    })
+
+    describe('LESS_THAN', () => {
+      it('should return true when value is less than threshold', () => {
+        const result = ConditionalLogicService.checkConditionByPattern({
+          type: 'LESS_THAN',
+          payload: { value: 10 },
+          scoreOrValue: 5,
+        })
+        expect(result).toBe(true)
+      })
+
+      it('should return false when value is not less than threshold', () => {
+        const result = ConditionalLogicService.checkConditionByPattern({
+          type: 'LESS_THAN',
+          payload: { value: 10 },
+          scoreOrValue: 15,
+        })
+        expect(result).toBe(false)
+      })
+
+      it('should return false when value is equal to threshold', () => {
+        const result = ConditionalLogicService.checkConditionByPattern({
+          type: 'LESS_THAN',
+          payload: { value: 10 },
+          scoreOrValue: 10,
+        })
+        expect(result).toBe(false)
+      })
+    })
+
+    describe('EQUAL', () => {
+      it('should return true when values are equal', () => {
+        const result = ConditionalLogicService.checkConditionByPattern({
+          type: 'EQUAL',
+          payload: { value: 5 },
+          scoreOrValue: 5,
+        })
+        expect(result).toBe(true)
+      })
+
+      it('should return false when values are not equal', () => {
+        const result = ConditionalLogicService.checkConditionByPattern({
+          type: 'EQUAL',
+          payload: { value: 5 },
+          scoreOrValue: 10,
+        })
+        expect(result).toBe(false)
+      })
+    })
+
+    describe('NOT_EQUAL', () => {
+      it('should return true when values are not equal', () => {
+        const result = ConditionalLogicService.checkConditionByPattern({
+          type: 'NOT_EQUAL',
+          payload: { value: 5 },
+          scoreOrValue: 10,
+        })
+        expect(result).toBe(true)
+      })
+
+      it('should return false when values are equal', () => {
+        const result = ConditionalLogicService.checkConditionByPattern({
+          type: 'NOT_EQUAL',
+          payload: { value: 5 },
+          scoreOrValue: 5,
+        })
+        expect(result).toBe(false)
+      })
+    })
+
+    describe('INCLUDES_OPTION', () => {
+      it('should return true when array includes the option value', () => {
+        const result = ConditionalLogicService.checkConditionByPattern({
+          type: 'INCLUDES_OPTION',
+          payload: { optionValue: '5' },
+          scoreOrValue: [1, 3, 5, 7],
+        })
+        expect(result).toBe(true)
+      })
+
+      it('should return false when array does not include the option value', () => {
+        const result = ConditionalLogicService.checkConditionByPattern({
+          type: 'INCLUDES_OPTION',
+          payload: { optionValue: '10' },
+          scoreOrValue: [1, 3, 5, 7],
+        })
+        expect(result).toBe(false)
+      })
+
+      it('should return false for non-array input', () => {
+        const result = ConditionalLogicService.checkConditionByPattern({
+          type: 'INCLUDES_OPTION',
+          payload: { optionValue: '5' },
+          scoreOrValue: 5,
+        })
+        expect(result).toBe(false)
+      })
+    })
+
+    describe('NOT_INCLUDES_OPTION', () => {
+      it('should return true when array does not include the option value', () => {
+        const result = ConditionalLogicService.checkConditionByPattern({
+          type: 'NOT_INCLUDES_OPTION',
+          payload: { optionValue: '10' },
+          scoreOrValue: [1, 3, 5, 7],
+        })
+        expect(result).toBe(true)
+      })
+
+      it('should return false when array includes the option value', () => {
+        const result = ConditionalLogicService.checkConditionByPattern({
+          type: 'NOT_INCLUDES_OPTION',
+          payload: { optionValue: '5' },
+          scoreOrValue: [1, 3, 5, 7],
+        })
+        expect(result).toBe(false)
+      })
+
+      it('should return false for non-array input', () => {
+        const result = ConditionalLogicService.checkConditionByPattern({
+          type: 'NOT_INCLUDES_OPTION',
+          payload: { optionValue: '5' },
+          scoreOrValue: 10,
+        })
+        expect(result).toBe(false)
+      })
+    })
+
+    describe('EQUAL_TO_SCORE', () => {
+      it('should return true when values are equal', () => {
+        const result = ConditionalLogicService.checkConditionByPattern({
+          type: 'EQUAL_TO_SCORE',
+          payload: { value: 5 },
+          scoreOrValue: 5,
+        })
+        expect(result).toBe(true)
+      })
+
+      it('should return false when values are not equal', () => {
+        const result = ConditionalLogicService.checkConditionByPattern({
+          type: 'EQUAL_TO_SCORE',
+          payload: { value: 5 },
+          scoreOrValue: 10,
+        })
+        expect(result).toBe(false)
+      })
+    })
+
+    describe('Null and Unsupported Conditions', () => {
+      it('should return false for null scoreOrValue', () => {
+        const result = ConditionalLogicService.checkConditionByPattern({
+          type: 'BETWEEN',
+          payload: { minValue: 0, maxValue: 10 },
+          scoreOrValue: null,
+        })
+        expect(result).toBe(false)
+      })
+
+      it('should return false for unsupported condition type', () => {
+        const result = ConditionalLogicService.checkConditionByPattern({
+          type: 'UNSUPPORTED_TYPE',
+          payload: {},
+          scoreOrValue: 5,
+        })
+        expect(result).toBe(false)
+      })
+    })
+  })
+})

--- a/src/modules/report/helpers/conditionalLogic/ConditionalLogicService.ts
+++ b/src/modules/report/helpers/conditionalLogic/ConditionalLogicService.ts
@@ -1,7 +1,9 @@
+import { ResponseValue } from '../../../../core/interfaces'
+
 type CheckConditionParams = {
   type: string
   payload: any
-  scoreOrValue: number | number[]
+  scoreOrValue: ResponseValue | ResponseValue[]
 }
 
 export class ConditionalLogicService {
@@ -14,6 +16,11 @@ export class ConditionalLogicService {
   }
 
   static checkConditionByPattern({ type, payload, scoreOrValue }: CheckConditionParams): boolean {
+    // Skipped responses do not match any condition
+    if (scoreOrValue === null) {
+      return false
+    }
+
     switch (type) {
       case 'BETWEEN':
         return payload.minValue < scoreOrValue && payload.maxValue > scoreOrValue
@@ -40,10 +47,12 @@ export class ConditionalLogicService {
         return scoreOrValue !== payload.value
 
       case 'INCLUDES_OPTION':
-        return Array.isArray(scoreOrValue) && scoreOrValue.includes(parseFloat(payload.optionValue))
+        const parsedIncludeValue = parseFloat(payload.optionValue)
+        return Array.isArray(scoreOrValue) && scoreOrValue.some((value) => value === parsedIncludeValue)
 
       case 'NOT_INCLUDES_OPTION':
-        return Array.isArray(scoreOrValue) && !scoreOrValue.includes(parseFloat(payload.optionValue))
+        const parsedExcludeValue = parseFloat(payload.optionValue)
+        return Array.isArray(scoreOrValue) && !scoreOrValue.some((value) => value === parsedExcludeValue)
 
       case 'EQUAL_TO_SCORE':
         return payload.value === scoreOrValue

--- a/src/modules/report/report.controller.ts
+++ b/src/modules/report/report.controller.ts
@@ -53,13 +53,17 @@ class ReportController {
       // Log into LD using workspace ID associated with applet (same as encryption account ID)
       await featureFlags.login(payload.applet.encryption.accountId)
 
+      const treatNullAsZero = !featureFlags.getFlag('enable-subscale-null-when-skipped')
+
       const responses: ActivityResponse[] = decryptActivityResponses({
         responses: payload.responses,
         appletPrivateKey: appletKeys.privateKey,
         appletEncryption: payload.applet.encryption,
       })
 
-      const applet = new AppletEntity(payload.applet)
+      // TODO: Remove `treatNullAsZero` parameter once feature flag is removed
+      // https://mindlogger.atlassian.net/browse/M2-8635
+      const applet = new AppletEntity(payload.applet, treatNullAsZero)
 
       const pdfPassword = await getPDFPassword(applet.id)
 

--- a/tests/fixtures/activity.json
+++ b/tests/fixtures/activity.json
@@ -4,13 +4,75 @@
   "splashScreen": "",
   "image": "",
   "showAllAtOnce": false,
-  "isSkippable": false,
+  "isSkippable": true,
   "isReviewable": false,
   "responseIsEditable": true,
   "isHidden": false,
   "scoresAndReports": {
     "generateReport": true,
     "showScoreSummary": true,
+    "reports": [
+      {
+        "type": "score",
+        "name": "Regular scores: Sum",
+        "id": "sumScore_regular_scores_sum",
+        "calculationType": "sum",
+        "itemsScore": ["item-1", "item-2"],
+        "message": "",
+        "itemsPrint": [],
+        "conditionalLogic": [
+          {
+            "name": "Equal to 0",
+            "id": "sumScore_regular_scores_sum_equal_to_0",
+            "flagScore": false,
+            "message": "",
+            "itemsPrint": [],
+            "match": "all",
+            "conditions": [
+              {
+                "itemName": "sumScore_regular_scores_sum",
+                "type": "EQUAL",
+                "payload": {
+                  "value": 0
+                }
+              }
+            ]
+          }
+        ],
+        "scoringType": "raw_score",
+        "subscaleName": ""
+      },
+      {
+        "type": "score",
+        "name": "Subscale scores",
+        "id": "sumScore_subscale_scores_sum",
+        "calculationType": "sum",
+        "itemsScore": ["item-1", "item-2"],
+        "message": "",
+        "itemsPrint": [],
+        "conditionalLogic": [
+          {
+            "name": "Subscale score is 0",
+            "id": "sumScore_subscale_scores_subscale_score_is_0",
+            "flagScore": false,
+            "message": "",
+            "itemsPrint": [],
+            "match": "all",
+            "conditions": [
+              {
+                "itemName": "sumScore_subscale_scores",
+                "type": "EQUAL",
+                "payload": {
+                  "value": 0
+                }
+              }
+            ]
+          }
+        ],
+        "scoringType": "score",
+        "subscaleName": "Subscale score"
+      }
+    ],
     "scores": [
       {
         "name": "postpartumdepression",
@@ -126,12 +188,103 @@
   },
   "subscaleSetting": {
     "calculateTotalScore": null,
-    "subscales": [],
+    "subscales": [
+      {
+        "name": "Subscale score",
+        "subscaleTableData": [
+          {
+            "id": "1",
+            "rawScore": "0 ~ 2",
+            "score": "10",
+            "optionalText": "",
+            "severity": null
+          }
+        ]
+      }
+    ],
     "totalScoresTableData": []
   },
   "id": "0656ccb3-3b25-4197-be8e-c8479599a12c",
   "order": 2,
   "items": [
+    {
+      "id": "item-1",
+      "name": "item-1",
+      "isHidden": false,
+      "allowEdit": true,
+      "question": "",
+      "responseType": "singleSelect",
+      "config": {
+        "addScores": true
+      },
+      "responseValues": {
+        "options": [
+          {
+            "id": "option-1",
+            "text": "Option 1",
+            "value": 0,
+            "score": 0,
+            "image": null,
+            "isHidden": false,
+            "color": null,
+            "alert": null,
+            "tooltip": null
+          },
+          {
+            "id": "option-2",
+            "text": "Option 2",
+            "value": 1,
+            "score": 1,
+            "image": null,
+            "isHidden": false,
+            "color": null,
+            "alert": null,
+            "tooltip": null
+          }
+        ],
+        "scores": [0, 10]
+      },
+      "conditionalLogic": null
+    },
+    {
+      "id": "item-2",
+      "name": "item-2",
+      "isHidden": false,
+      "allowEdit": true,
+      "question": "",
+      "responseType": "singleSelect",
+      "config": {
+        "addScores": true
+      },
+      "responseValues": {
+        "options": [
+          {
+            "id": "option-1",
+            "text": "Option 1",
+            "value": 0,
+            "score": 0,
+            "image": null,
+            "isHidden": false,
+            "color": null,
+            "alert": null,
+            "tooltip": null
+          },
+          {
+            "id": "option-2",
+            "text": "Option 2",
+            "value": 1,
+            "score": 1,
+            "image": null,
+            "isHidden": false,
+            "color": null,
+            "alert": null,
+            "tooltip": null
+          }
+        ],
+        "scores": [0, 10]
+      },
+      "conditionalLogic": null
+    },
     {
       "question": "MotherDOB",
       "responseType": "multiSelect",

--- a/tests/models/activity.test.ts
+++ b/tests/models/activity.test.ts
@@ -1,81 +1,136 @@
 import { ActivityEntity } from '../../src/models'
-import { IActivity, IActivityScoresAndReportsConditionalLogic as ConditionalLogic } from '../../src/core/interfaces'
+import {
+  IActivity,
+  IActivityScoresAndReportsConditionalLogic as ConditionalLogic,
+  Score,
+  Map,
+} from '../../src/core/interfaces'
+import mockActivityJson from '../fixtures/activity.json'
 
-const activity = new ActivityEntity({} as IActivity, [])
+test('scoring skipped answers', () => {
+  let result: { scores: Map<Score>; conditionalVisibility: Map<boolean> }
+  const mockActivity = mockActivityJson as unknown as IActivity
 
-test('score report conditions', () => {
-  const conditional: ConditionalLogic = {
-    match: 'all',
-    conditions: [
-      {
-        itemName: 'sumScore_postpartumdepression',
-        type: 'BETWEEN',
-        payload: {
-          minValue: 5,
-          maxValue: 10,
-        },
-      },
-    ],
-  }
+  const legacyActivity = new ActivityEntity(mockActivity, mockActivity.items, true)
 
-  expect(activity.testVisibility(conditional, {})).toBeFalsy()
-  expect(activity.testVisibility(conditional, { sumScore_postpartumdepression: 12 })).toBeFalsy()
-  expect(activity.testVisibility(conditional, { sumScore_postpartumdepression: 8 })).toBeTruthy()
-  expect(activity.testVisibility(conditional, { sumScore_postpartumdepression: 1 })).toBeFalsy()
+  // Legacy behaviour treats skipped answers as 0
+  // When all answers are skipped, calculations use 0 for both regular and subscale scores
+  result = legacyActivity.evaluateScores([{ value: null }, { value: null }])
+  expect(result.scores).toEqual({
+    'item-1': 0,
+    'item-2': 0,
+    sumScore_regular_scores_sum: 0,
+    sumScore_subscale_scores_sum: 10,
+  })
+
+  // When null is included in calculation, it is treated as 0
+  result = legacyActivity.evaluateScores([{ value: null }, { value: 0 }])
+  expect(result.scores).toEqual({
+    'item-1': 0,
+    'item-2': 0,
+    sumScore_regular_scores_sum: 0,
+    sumScore_subscale_scores_sum: 10,
+  })
+
+  const activity = new ActivityEntity(mockActivity, mockActivity.items, false)
+
+  // New behaviour treats skipped answers as null
+  // When all answers are skipped, calculations use null for both regular and subscale scores
+  result = activity.evaluateScores([{ value: null }, { value: null }])
+  expect(result.scores).toEqual({
+    'item-1': null,
+    'item-2': null,
+    sumScore_regular_scores_sum: null,
+    sumScore_subscale_scores_sum: null,
+  })
+
+  // When null is included in calculation, it is treated as 0
+  result = activity.evaluateScores([{ value: null }, { value: 0 }])
+  expect(result.scores).toEqual({
+    'item-1': null,
+    'item-2': 0,
+    sumScore_regular_scores_sum: 0,
+    sumScore_subscale_scores_sum: 10,
+  })
 })
 
-test('section report conditions', () => {
-  const conditions = [
-    {
-      itemName: 'Q1',
-      type: 'EQUAL_TO_OPTION',
-      payload: {
-        optionValue: '4',
-      },
-    },
-    {
-      itemName: 'sumScore_postpartumdepression',
-      type: 'GREATER_THAN',
-      payload: {
-        value: 0,
-      },
-    },
-    {
-      itemName: 'sumScore_postpartumdepression_high',
-      type: 'EQUAL',
-      payload: {
-        value: 0,
-      },
-    },
-  ]
+describe('report conditions', () => {
+  const activity = new ActivityEntity({} as IActivity, [], false)
 
-  expect(activity.testVisibility({ conditions, match: 'any' } as ConditionalLogic, {})).toBeFalsy()
-  expect(activity.testVisibility({ conditions, match: 'any' } as ConditionalLogic, { Q1: 4 })).toBeTruthy()
-  expect(
-    activity.testVisibility({ conditions, match: 'any' } as ConditionalLogic, { sumScore_postpartumdepression: 1 }),
-  ).toBeTruthy()
-  expect(
-    activity.testVisibility({ conditions, match: 'any' } as ConditionalLogic, {
-      sumScore_postpartumdepression_high: 0,
-    }),
-  ).toBeTruthy()
+  test('score report conditions', () => {
+    const conditional: ConditionalLogic = {
+      match: 'all',
+      conditions: [
+        {
+          itemName: 'sumScore_postpartumdepression',
+          type: 'BETWEEN',
+          payload: {
+            minValue: 5,
+            maxValue: 10,
+          },
+        },
+      ],
+    }
 
-  expect(activity.testVisibility({ conditions, match: 'all' } as ConditionalLogic, {})).toBeFalsy()
-  expect(activity.testVisibility({ conditions, match: 'all' } as ConditionalLogic, { Q1: 4 })).toBeFalsy()
-  expect(
-    activity.testVisibility({ conditions, match: 'all' } as ConditionalLogic, { sumScore_postpartumdepression: 1 }),
-  ).toBeFalsy()
-  expect(
-    activity.testVisibility({ conditions, match: 'all' } as ConditionalLogic, {
-      sumScore_postpartumdepression_high: 0,
-    }),
-  ).toBeFalsy()
+    expect(activity.testVisibility(conditional, {})).toBeFalsy()
+    expect(activity.testVisibility(conditional, { sumScore_postpartumdepression: 12 })).toBeFalsy()
+    expect(activity.testVisibility(conditional, { sumScore_postpartumdepression: 8 })).toBeTruthy()
+    expect(activity.testVisibility(conditional, { sumScore_postpartumdepression: 1 })).toBeFalsy()
+  })
 
-  expect(
-    activity.testVisibility({ conditions, match: 'all' } as ConditionalLogic, {
-      Q1: 4,
-      sumScore_postpartumdepression: 1,
-      sumScore_postpartumdepression_high: 0,
-    }),
-  ).toBeTruthy()
+  test('section report conditions', () => {
+    const conditions = [
+      {
+        itemName: 'Q1',
+        type: 'EQUAL_TO_OPTION',
+        payload: {
+          optionValue: '4',
+        },
+      },
+      {
+        itemName: 'sumScore_postpartumdepression',
+        type: 'GREATER_THAN',
+        payload: {
+          value: 0,
+        },
+      },
+      {
+        itemName: 'sumScore_postpartumdepression_high',
+        type: 'EQUAL',
+        payload: {
+          value: 0,
+        },
+      },
+    ]
+
+    expect(activity.testVisibility({ conditions, match: 'any' } as ConditionalLogic, {})).toBeFalsy()
+    expect(activity.testVisibility({ conditions, match: 'any' } as ConditionalLogic, { Q1: 4 })).toBeTruthy()
+    expect(
+      activity.testVisibility({ conditions, match: 'any' } as ConditionalLogic, { sumScore_postpartumdepression: 1 }),
+    ).toBeTruthy()
+    expect(
+      activity.testVisibility({ conditions, match: 'any' } as ConditionalLogic, {
+        sumScore_postpartumdepression_high: 0,
+      }),
+    ).toBeTruthy()
+
+    expect(activity.testVisibility({ conditions, match: 'all' } as ConditionalLogic, {})).toBeFalsy()
+    expect(activity.testVisibility({ conditions, match: 'all' } as ConditionalLogic, { Q1: 4 })).toBeFalsy()
+    expect(
+      activity.testVisibility({ conditions, match: 'all' } as ConditionalLogic, { sumScore_postpartumdepression: 1 }),
+    ).toBeFalsy()
+    expect(
+      activity.testVisibility({ conditions, match: 'all' } as ConditionalLogic, {
+        sumScore_postpartumdepression_high: 0,
+      }),
+    ).toBeFalsy()
+
+    expect(
+      activity.testVisibility({ conditions, match: 'all' } as ConditionalLogic, {
+        Q1: 4,
+        sumScore_postpartumdepression: 1,
+        sumScore_postpartumdepression_high: 0,
+      }),
+    ).toBeTruthy()
+  })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,20 +1,21 @@
 {
   "compilerOptions": {
-    "target": "es2021", /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
-    "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
-    "module": "commonjs", /* Specify what module code is generated. */
-    "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
-    "outDir": "./dist", /* Specify an output folder for all emitted files. */
-    "esModuleInterop": true, /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
-    "forceConsistentCasingInFileNames": true, /* Ensure that casing is correct in imports. */
-    "strict": true, /* Enable all strict type-checking options. */
-    "strictPropertyInitialization": false,             /* Check for class properties that are declared but not set in the constructor. */
-    "skipLibCheck": true, /* Skip type checking all .d.ts files. */
+    "target": "es2021" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "experimentalDecorators": true /* Enable experimental support for TC39 stage 2 draft decorators. */,
+    "emitDecoratorMetadata": true /* Emit design-type metadata for decorated declarations in source files. */,
+    "module": "commonjs" /* Specify what module code is generated. */,
+    "sourceMap": true /* Create source map files for emitted JavaScript files. */,
+    "outDir": "./dist" /* Specify an output folder for all emitted files. */,
+    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
+    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
+    "strict": true /* Enable all strict type-checking options. */,
+    "strictPropertyInitialization": false /* Check for class properties that are declared but not set in the constructor. */,
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */,
+    "resolveJsonModule": true,
 
     "baseUrl": "./src",
     "paths": {
-      "~": ["./*"],
+      "~": ["./*"]
     }
   },
   "exclude": []


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [x] Tests for the changes have been added

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-8650](https://mindlogger.atlassian.net/browse/M2-8650)
🔗 [Jira Ticket M2-6099](https://mindlogger.atlassian.net/browse/M2-6099)
🔗 [Jira Ticket M2-8169](https://mindlogger.atlassian.net/browse/M2-8169)

Till now, in PDF report generation, if a **raw score** or **subscale score** value was calculated from item responses that have been skipped, those values have been getting interpreted as `0`, which creates ambiguity with responses that, when their score value is `0`, indicates a meaningful score that should be treated as distinct from a skipped item.

This task is to update the Report Server to interpret the scores of missing responses as `null` rather than `0`. So anywhere in report generation that uses conditional logic based on a raw score or a subscale score, if the value was calculated entirely based on responses that where skipped, that score should now in turn be interpreted as `null`.

So previously, if conditional logic that compared a score value against `0`, but that score value is now `null` due to this change, that condition should now resolve to “no match” (false), and any section whose visibility depends on such a condition should be omitted. As well, any calculated totals, averages, or percentages based strictly on skipped items should be omitted from the report.

> [!NOTE]
> @sultanofcardio just identified that my minor refactoring changes also fixed 2 bugs, which have been added to the PR description.

> [!TIP]
> I tried to organize my work into digestible commits with appropriate descriptions. Reviewing the code may be easier from the [Commits](https://github.com/ChildMindInstitute/mindlogger-report-server/pull/83/commits) tab.
> 
> When reviewing [this commit](https://github.com/ChildMindInstitute/mindlogger-report-server/pull/83/commits/43b5ac9c3460545d51dd30c5133c01b4ef087b2f), make sure to check the **Hide whitespace** checkbox to accommodate the change of indentation:
> <img src="https://github.com/user-attachments/assets/d63326dc-295f-483e-9876-d9cf9bd1981c" width="200">


### 🪤 Peer Testing

#### Preconditions:

-   Applet containing activity with at least one skippable item with scoring enabled and can produce a valid score of `0`
-   Activity is configured with a subscale with lookup table that maps a raw score of `0` to a T-score of `0`
-   Applet is configured to connect to report server
-   Activity is configured to email a PDF report to an accessible email address
-   Activity has **Scores & Reports > Show Score Summary** checkbox checked
-   Also under **Scores & Reports**, report has a section that is linked to the subscale, with conditional logic that displays `Subscale is 0` only when the subscale's value is `0`:

|  | |
| - | - |
| ![CleanShot 2025-02-05 at 12 34 58@2x](https://github.com/user-attachments/assets/b9509443-c7b8-418c-a350-6225d7e11996) | ![CleanShot 2025-02-05 at 12 34 20@2x](https://github.com/user-attachments/assets/93283477-cf07-4e26-92df-df26709d2e2a) |

#### Testing procedure:

1. Add these lines to the top of the `getFlag` the function in `FeatureFlagsService.ts` (feature flag enabled):
    ```ts
    if (flag === 'enable-subscale-null-when-skipped') {
      return true
    }
    ```
1.  Log into the Web App as a valid respondent for the applet
3.  Complete an assessment of the activity, **without skipping** the item(s) and entering a response that evaluates to a score of `0`
    **Expected result:** Check the email that is configured to receive the report and open the PDF that is delivered.
    -   In the report, confirm that the PDF starts with a Summary page that shows `0` as the subscale's score total
    -   In the report, confirm that the `Subscale is 0` section **is visible**.
5.  Complete an assessment a second time, this time **skipping** all item(s).
    **Expected result:** Check the email that is configured to receive the report and open the PDF that is delivered.
    -   In the report, confirm that the PDF omits the Summary page (subscale's total score is absent because there is no data)
    -   In the report, confirm that the `Subscale is 0` section **is omitted**.
2. Update the top of the `getFlag` the function to test with the feature flag disabled:
    ```ts
    if (flag === 'enable-subscale-null-when-skipped') {
      return false
    }
    ```
2. Repeat step 4.
    **Expected result:** Check the email that is configured to receive the report and open the PDF that is delivered.
    -   In the report, confirm that the PDF starts with a Summary page that shows `0` as the subscale's score total
    -   In the report, confirm that the `Subscale is 0` section **is visible**.