### PR TITLE
docker-entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ COPY package*.json /app/
 RUN npm ci
 
 COPY ./ /app/
+RUN chmod a+x docker-entrypoint.sh
 
 RUN npm run build
 
@@ -32,5 +33,7 @@ RUN addgroup webuser \
 
 USER webuser
 
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["node", "./dist/src/app.js"]
+
 EXPOSE 3000/tcp

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if [ "${DD_TRACE_ENABLED}" == "true" ]; then
+  TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600") && \
+    export DD_AGENT_HOST=$(curl http://169.254.169.254/latest/meta-data/local-ipv4 -H "X-aws-ec2-metadata-token: $TOKEN")
+  export LOG_JSON_FORMAT=true
+fi
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,7 +3,6 @@
 if [ "${DD_TRACE_ENABLED}" == "true" ]; then
   TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600") && \
     export DD_AGENT_HOST=$(curl http://169.254.169.254/latest/meta-data/local-ipv4 -H "X-aws-ec2-metadata-token: $TOKEN")
-  export LOG_JSON_FORMAT=true
 fi
 
 set -o errexit

--- a/src/app.ts
+++ b/src/app.ts
@@ -39,4 +39,5 @@ app.post('/decrypt-user-responses', serverController.decryptUserResponses)
 
 app.listen(port, () => {
   logger.info(`MindLogger Report Server listening on port ${port}!`)
+  logger.info(`Datadog trace status: ${process.env.DD_TRACE_ENABLED}`)
 })


### PR DESCRIPTION
### 📝 Description

The Datadog tracer needs to be configured with the IP of the host it is running on in order to talk to the agent to send traces.  A new startup script to match the [one in the backend](https://github.com/ChildMindInstitute/mindlogger-backend-refactor/blob/11571c7f69479c1e67c0989725bc509c6afb423e/compose/fastapi/start-backend-datadog#L3) has been created to duplicate that functionality.

Changes include:

- Added docker entrypoint script
- Modified Dockerfile


### 🪤 Peer Testing

Build the new container:

```shell
docker build -t mindlogger-report-server:latest -f ./Dockerfile .
```

Ensure server starts up and can respond to requests:

```shell
docker run --rm -i -t --init \
-v "./keys:/app/keys" \
-p "3000:3000" \
--name mindlogger-report-server \
mindlogger-report-server:latest
```