### PR TITLE
fix: Do not skip score reports following first encountered `null` report score (M2-8777)

### DIFF
--- a/src/models/activity.ts
+++ b/src/models/activity.ts
@@ -130,7 +130,7 @@ export class ActivityEntity {
           const calculatedScore = scores[report.id]
           if (calculatedScore === null) {
             scores[report.id] = null
-            break
+            continue
           }
 
           const genderItemIndex = this.items.findIndex((item) => item.name == LookupTableItems.Gender_screen)

--- a/tests/fixtures/activity.json
+++ b/tests/fixtures/activity.json
@@ -71,6 +71,36 @@
         ],
         "scoringType": "score",
         "subscaleName": "Subscale score"
+      },
+      {
+        "type": "score",
+        "name": "Regular scores: Another sum score",
+        "id": "sumScore_regular_scores_another_sum_score",
+        "calculationType": "sum",
+        "itemsScore": ["item-1", "item-2"],
+        "message": "",
+        "itemsPrint": [],
+        "conditionalLogic": [
+          {
+            "name": "Equal to 0",
+            "id": "sumScore_regular_scores_another_sum_score_equal_to_0",
+            "flagScore": false,
+            "message": "",
+            "itemsPrint": [],
+            "match": "all",
+            "conditions": [
+              {
+                "itemName": "sumScore_regular_scores_sum",
+                "type": "EQUAL",
+                "payload": {
+                  "value": 0
+                }
+              }
+            ]
+          }
+        ],
+        "scoringType": "raw_score",
+        "subscaleName": ""
       }
     ],
     "scores": [
@@ -80,16 +110,11 @@
         "calculationType": "average",
         "minScore": 1,
         "maxScore": 3,
-        "itemsScore": [
-          "5e90d62b-65b8-4567-b259-2214d74a50e0"
-        ],
+        "itemsScore": ["5e90d62b-65b8-4567-b259-2214d74a50e0"],
         "showMessage": true,
         "message": "Scores on the EDPS range from 0 to 30, with any score at or above 10 indicating possible depression. ",
         "printItems": true,
-        "itemsPrint": [
-          "5e90d62b-65b8-4567-b259-2214d74a50e0",
-          "acc8d88b-f205-4baa-9a29-551a404a36dd"
-        ],
+        "itemsPrint": ["5e90d62b-65b8-4567-b259-2214d74a50e0", "acc8d88b-f205-4baa-9a29-551a404a36dd"],
         "conditionalLogic": [
           {
             "name": "high",
@@ -98,10 +123,7 @@
             "showMessage": true,
             "message": "**++The mother’s score on the EPDS is [[sumScore_postpartumdepression]]. This score indicates the likely presence of postpartum depression.++**\n\nIf not currently being addressed, high scores on this scale may signal the need for further clinical evaluation and attention depending on the level of difficulties encountered in the home, work, or social environments. ",
             "printItems": true,
-            "itemsPrint": [
-              "5e90d62b-65b8-4567-b259-2214d74a50e0",
-              "acc8d88b-f205-4baa-9a29-551a404a36dd"
-            ],
+            "itemsPrint": ["5e90d62b-65b8-4567-b259-2214d74a50e0", "acc8d88b-f205-4baa-9a29-551a404a36dd"],
             "match": "all",
             "conditions": [
               {
@@ -121,10 +143,7 @@
             "showMessage": true,
             "message": "**The mother’s score on the EPDS is [[sumScore_postpartumdepression]].** This score indicates that postpartum depression is not present in the mother.\n\nIf you remain concerned about their symptoms, functioning, or well-being, please advise and assist them to seek additional consultation and guidance, even though their score is in the low-risk range.",
             "printItems": true,
-            "itemsPrint": [
-              "5e90d62b-65b8-4567-b259-2214d74a50e0",
-              "acc8d88b-f205-4baa-9a29-551a404a36dd"
-            ],
+            "itemsPrint": ["5e90d62b-65b8-4567-b259-2214d74a50e0", "acc8d88b-f205-4baa-9a29-551a404a36dd"],
             "match": "all",
             "conditions": [
               {
@@ -146,10 +165,7 @@
         "showMessage": true,
         "message": "## Edinburgh Postnatal Depression Scale (EDPS)\n\nA common complication of childbearing is postpartum depression, which refers to the onset of depression or depression-like symptoms following childbirth. The EDPS identifies mothers at risk for \"perinatal\" depression. \n\nThe EDPS recommends the following resources:\n-  National Women's Health Information Center <www.4women.gov>\n- Postpartum\nSupport International <www.chss.iup.edu/postpartum>\n- Depression after Delivery\n<www.depressionafterdelivery.com>",
         "printItems": true,
-        "itemsPrint": [
-          "5e90d62b-65b8-4567-b259-2214d74a50e0",
-          "acc8d88b-f205-4baa-9a29-551a404a36dd"
-        ],
+        "itemsPrint": ["5e90d62b-65b8-4567-b259-2214d74a50e0", "acc8d88b-f205-4baa-9a29-551a404a36dd"],
         "conditionalLogic": {
           "name": "section-condition",
           "id": "180bbf86-b427-423b-bd1c-6fa590404cfe",

--- a/tests/models/activity.test.ts
+++ b/tests/models/activity.test.ts
@@ -21,6 +21,7 @@ test('scoring skipped answers', () => {
     'item-2': 0,
     sumScore_regular_scores_sum: 0,
     sumScore_subscale_scores_sum: 10,
+    sumScore_regular_scores_another_sum_score: 0,
   })
 
   // When null is included in calculation, it is treated as 0
@@ -30,6 +31,7 @@ test('scoring skipped answers', () => {
     'item-2': 0,
     sumScore_regular_scores_sum: 0,
     sumScore_subscale_scores_sum: 10,
+    sumScore_regular_scores_another_sum_score: 0,
   })
 
   const activity = new ActivityEntity(mockActivity, mockActivity.items, false)
@@ -42,15 +44,7 @@ test('scoring skipped answers', () => {
     'item-2': null,
     sumScore_regular_scores_sum: null,
     sumScore_subscale_scores_sum: null,
-  })
-
-  // When null is included in calculation, it is treated as 0
-  result = activity.evaluateScores([{ value: null }, { value: 0 }])
-  expect(result.scores).toEqual({
-    'item-1': null,
-    'item-2': 0,
-    sumScore_regular_scores_sum: 0,
-    sumScore_subscale_scores_sum: 10,
+    sumScore_regular_scores_another_sum_score: null,
   })
 })
 


### PR DESCRIPTION
<!-- Use this template as a guide to describe your pull request, and adjust as necessary. -->
<!-- Include information that helps your peers review your updates and understand this    -->
<!-- repository's history of changes over time.                                           -->

<!-- Delete any options that are not relevant -->

- [x] Tests for the changes have been added
- [ ] Related documentation has been added / updated

### 📝 Description

<!-- Contributions are welcome! If there is a corresponding      -->
<!-- JIRA ticket, link to it by replacing `#` with ticket number -->

🔗 [Jira Ticket M2-8777](https://mindlogger.atlassian.net/browse/M2-8777)

When #83 was merged, there was a small bug in the control flow of `evaluateScores` that caused all score reports following the first encountered subscale score report evaluating to `null` to be skipped from processing. This resulted in expected sections missing from the PDF.

### 🪤 Peer Testing

#### Preconditions:

-   An applet properly configured with this Report Server
-   An activity with skippable items and scoring enabled on those items
-   The activity's Scores & Reports pane has 2+ score reports set up, with the first report using a **subscale score**. This subscale score must configured such that it can possibly evaluate to `null`, i.e., if the associated items were skipped during an assessment.

#### Procedure:

1.  In the Web App perform an assessment on the activity, and answer the questions such that the first score report evaluates to `null`, but a subsequent report does NOT evaluate to `null` (results in a numeric score).
2.  Inspect the emailed report.
    -   **Expected outcome:** The content for the first score report (`null` score) is omitted, but the content for the subsequent report (valid numeric score) is included.
