### PR TITLE
Alpine base image does not have bash

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 if [ "${DD_TRACE_ENABLED}" == "true" ]; then
   TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600") && \


### PR DESCRIPTION
The alpine docker image doesn't have `/bin/bash` this causes the docker entrypoint to fail and not set the necessary variables for Datadog