### PR TITLE
fix: allow `null` answers in variable replacement (M2-8802)

### DIFF
--- a/src/core/helpers/markdownVariableReplacer/MarkdownVariableReplacer.ts
+++ b/src/core/helpers/markdownVariableReplacer/MarkdownVariableReplacer.ts
@@ -121,6 +121,6 @@ export class MarkdownVariableReplacer {
     if (!(variableName in this.answers)) {
       return ''
     }
-    return this.answers[variableName].toString()
+    return this.answers[variableName]?.toString() ?? ''
   }
 }


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-8802](https://mindlogger.atlassian.net/browse/M2-8802)

If you try to output the value of a score in a report, and that score is `null`, then the Report Server crashes when trying to generate it. This PR fixes that.

### 🪤 Peer Testing

1. Create an applet configured to the Report Server.
2. Create an activity with skippable item(s) and associated scores.
3. Configure a score report based on Raw Score derived from skippable items. In the "Show a message" section, include a variable reference to the score ID: `[[sumScore_whatever]]`
4. Submit an assessment skipping all items.
5. Go to Dataviz for that submission and click **Download Latest Report**.
    **Expected outcome:** The report PDF should download, and for the message containing that variable placeholder, it should just show an empty string there. (With this bug, it will fail and generate a 4xx error.)

### ✏️ Notes

It's already been identified by QA that the score report message whose score evaluates to `null` should be omitted altogether in that case, but it's not as urgent as this bug.