### PR TITLE
fix: Transform `Error` objects for logging (M2-10561)

### DIFF
--- a/src/core/services/LoggerService.ts
+++ b/src/core/services/LoggerService.ts
@@ -3,7 +3,7 @@ import { createLogger, format, transports } from 'winston'
 export const loggerOptions = {
   level: 'info',
   exitOnError: false,
-  format: format.json(),
+  format: format.combine(format.errors({ stack: true }), format.json()),
   transports: [new transports.Console()],
 }
 


### PR DESCRIPTION
### 📝 Description

🔗 [Jira Ticket M2-10561](https://mindlogger.atlassian.net/browse/M2-10561)

Details about the error on the report server could help with debugging the Jira issue, but currently `Error` objects cannot be serialized by the `winston` logging library. Using [`format.combine`](https://github.com/winstonjs/winston#combining-formats) to add [`format.errors`](https://github.com/winstonjs/logform#errors) will allow us to log details about `Error` objects.

### 🪤 Peer Testing

Setup:

- `git checkout M2-10561-log-errors`
- Configure `keys` and `outputs` directories as described in README

Lint and test:

    npm run lint
    npm test

Build and run:

    docker build -t mindlogger-report-server:latest .
    docker run -v "./keys:/app/keys" -p "3000:3000"  --name mindlogger-report-server mindlogger-report-server:latest